### PR TITLE
multiple fixes in setup / walkthrough

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
 	"name": "stexide",
-	"version": "1.0",
+	"version": "1.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "stexide",
-			"version": "1.0",
+			"version": "1.0.2",
 			"license": "GPL3",
 			"dependencies": {
+				"@redhat-developer/vscode-wizard": "^0.3.1",
 				"@vscode/codicons": "^0.0.30",
 				"@vscode/webview-ui-toolkit": "^1.0.0",
 				"locate-java-home": "^1.1.2",
 				"shell-quote": "^1.7.3",
 				"vscode-languageclient": "^8.0.1",
-				"vscode-wizard": "^0.2.20",
 				"websocket-stream": "^5.5.2"
 			},
 			"devDependencies": {
@@ -256,6 +256,17 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@redhat-developer/vscode-wizard": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-wizard/-/vscode-wizard-0.3.1.tgz",
+			"integrity": "sha512-uQs6xEV6GJXHvciA+PaLzo+j2Hz34N+jcPzG0yqsw+VurrpUEipx01/IBgFO9jrVo7uxsfoXvlszRThfI6uuSw==",
+			"dependencies": {
+				"handlebars": "^4.7.3"
+			},
+			"engines": {
+				"vscode": "^1.54.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -5184,17 +5195,6 @@
 			"integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
 			"dev": true
 		},
-		"node_modules/vscode-wizard": {
-			"version": "0.2.20",
-			"resolved": "https://registry.npmjs.org/vscode-wizard/-/vscode-wizard-0.2.20.tgz",
-			"integrity": "sha512-yUbkYcJNUDGvxUKYwOGVLY8ZMaLwhbJFFxycQMn19jXpDQhqweErKTtPkTwZ8VEMFglkClzkO9vJ1Ny3QH/rzQ==",
-			"dependencies": {
-				"handlebars": "^4.7.3"
-			},
-			"engines": {
-				"vscode": "^1.54.0"
-			}
-		},
 		"node_modules/watchpack": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -5731,6 +5731,14 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@redhat-developer/vscode-wizard": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@redhat-developer/vscode-wizard/-/vscode-wizard-0.3.1.tgz",
+			"integrity": "sha512-uQs6xEV6GJXHvciA+PaLzo+j2Hz34N+jcPzG0yqsw+VurrpUEipx01/IBgFO9jrVo7uxsfoXvlszRThfI6uuSw==",
+			"requires": {
+				"handlebars": "^4.7.3"
 			}
 		},
 		"@tootallnate/once": {
@@ -9392,14 +9400,6 @@
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
 			"integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
 			"dev": true
-		},
-		"vscode-wizard": {
-			"version": "0.2.20",
-			"resolved": "https://registry.npmjs.org/vscode-wizard/-/vscode-wizard-0.2.20.tgz",
-			"integrity": "sha512-yUbkYcJNUDGvxUKYwOGVLY8ZMaLwhbJFFxycQMn19jXpDQhqweErKTtPkTwZ8VEMFglkClzkO9vJ1Ny3QH/rzQ==",
-			"requires": {
-				"handlebars": "^4.7.3"
-			}
 		},
 		"watchpack": {
 			"version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -143,13 +143,18 @@
 			{
 				"title": "sTeX",
 				"properties": {
-					"stexide.jarpath": {
+					"stexide.mmt.jarPath": {
 						"type": "string",
 						"default": "",
 						"markdownDescription": "Path to your [MMT.jar](https://github.com/UniFormal/MMT/releases)"
 					},
-					"stexide.mmtport": {
+					"stexide.mmt.javaHome": {
 						"type": "string",
+						"default": "",
+						"markdownDescription": "Path to specific Java installation (_optional, leave blank for default_)"
+					},
+					"stexide.mmt.port": {
+						"type": "integer",
 						"default": "8090",
 						"markdownDescription": "The port at which MMT serves xhtml documents"
 					},

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
 	"name": "stexide",
 	"displayName": "sTeX",
 	"description": "",
-	"icon":"img/stex.png",
+	"icon": "img/stex.png",
 	"repository": {
 		"type": "git",
 		"url": "github:slatex/stex-IDE"
 	},
 	"publisher": "kwarc",
 	"version": "1.0.2",
-	"license":"GPL3",
+	"license": "GPL3",
 	"engines": {
 		"vscode": "^1.67.0"
 	},
@@ -18,7 +18,7 @@
 		"Language Packs"
 	],
 	"bugs": {
-		"url":"https://github.com/slatex/sTeX-IDE/issues"
+		"url": "https://github.com/slatex/sTeX-IDE/issues"
 	},
 	"activationEvents": [
 		"workspaceContains:**/*.tex"
@@ -159,10 +159,14 @@
 						"markdownDescription": "The URL of the remote MathHub server for repository management"
 					},
 					"stexide.preview": {
-						"type":"string",
+						"type": "string",
 						"default": "on save",
 						"markdownDescription": "When to parse the sTeX document and show the HTML preview window",
-						"enum":["on save", "on edit", "manually"],
+						"enum": [
+							"on save",
+							"on edit",
+							"manually"
+						],
 						"enumDescriptions": [
 							"Everytime a .tex file is saved (whether changed or not)",
 							"Everytime a .tex file is edited (dangerous!)",
@@ -206,12 +210,12 @@
 		"webpack-cli": "^4.9.2"
 	},
 	"dependencies": {
+		"@redhat-developer/vscode-wizard": "^0.3.1",
 		"@vscode/codicons": "^0.0.30",
 		"@vscode/webview-ui-toolkit": "^1.0.0",
 		"locate-java-home": "^1.1.2",
 		"shell-quote": "^1.7.3",
 		"vscode-languageclient": "^8.0.1",
-		"vscode-wizard": "^0.2.20",
 		"websocket-stream": "^5.5.2"
 	},
 	"extensionDependencies": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,16 +3,14 @@ import * as vscode from 'vscode';
 import {registerCommands} from './shared/commands';
 import { launchLocal, launchRemote } from './nonweb/launches';
 import { STeXContext } from './shared/context';
-import { getJarpath, getMathHub, setup } from './nonweb/setup';
+import { getJarPath, getMathHub, setup } from './nonweb/setup';
 
 let stexc : STeXContext;
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
 	stexc = new STeXContext(context);
-	if (getMathHub() && getJarpath()) {
-		launchLocal(stexc);
-	} else {
-		setup(stexc);
+	if (!getMathHub() || !getJarPath()) {
+		await setup(stexc);
 	}
 	//launchRemote(stexc);
 }

--- a/src/nonweb/launches.ts
+++ b/src/nonweb/launches.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import { handleClient, languageclient} from "../client";
 import { getJavaOptions } from "../util/java";
 import { STeXContext } from "../shared/context";
-import { getMathHub } from "./setup";
+import { getJarPath, getMathHub } from "./setup";
 
 export function launchRemote(context: STeXContext) {
 	// The server is started as a separate app and listens on port 5007
@@ -44,7 +44,7 @@ export function launchLocal(context: STeXContext) {
 
 export function launchSTeXServerWithArgs(context: STeXContext,jarPath:string,mathhub:string) {
 	const config = vscode.workspace.getConfiguration("stexide");
-	const portO = config.get<string>("mmtport");
+	const portO = config.get<string>("mmt.port");
 	if(!portO) { 
 		const message =
 		"Port not set";
@@ -82,12 +82,11 @@ export function launchSTeXServerWithArgs(context: STeXContext,jarPath:string,mat
 }
 
 function launchSTeXServer(context: STeXContext/*,javaHome: string*/) {
-	const config = vscode.workspace.getConfiguration("stexide");
     /*
 	context.outputChannel.appendLine(`Java home: ${javaHome}`);
 	const javaPath = path.join(javaHome, "bin", "java");
 	 */
-	const jarPathO = config.get<string>("jarpath");
+	const jarPathO = getJarPath();
 	if(!jarPathO) { 
 		const message =
 		"Path to MMT jar not set";

--- a/src/nonweb/setup.ts
+++ b/src/nonweb/setup.ts
@@ -1,7 +1,6 @@
-import { IWizardWorkflowManager, PerformFinishResponse, SEVERITY, BUTTONS, ValidatorResponse, WebviewWizard, WizardDefinition } from "@redhat-developer/vscode-wizard";
-import { launchSTeXServerWithArgs } from "./launches";
+import { IWizardWorkflowManager, PerformFinishResponse, SEVERITY, BUTTONS, ValidatorResponse, WebviewWizard, WizardDefinition, IWizardPage } from "@redhat-developer/vscode-wizard";
 import { STeXContext } from "../shared/context";
-import { exec } from "child_process";
+import { spawn } from "child_process";
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
@@ -16,174 +15,224 @@ export function getMathHub(): string | undefined {
     if (mathhub) {
         return mathhub;
     }
-    const mathhubEnvConfig = getMathhubEnvConfigPath()
+    const mathhubEnvConfig = getMathhubEnvConfigPath();
     if (fs.existsSync(mathhubEnvConfig)) {
         return fs.readFileSync(mathhubEnvConfig).toString().trim();
     }
     return undefined;
 }
 
-export function getJarpath(): string | undefined {
+export function getJarPath(): string | undefined {
     const config = vscode.workspace.getConfiguration("stexide");
-    return config.get<string>("jarpath")?.trim();
+    return config.get<string>("mmt.jarPath")?.trim();
 }
 
 function setMathHub(mathhubPath: string) {
-    const mathhubEnvConfig = getMathhubEnvConfigPath()
+    const mathhubEnvConfig = getMathhubEnvConfigPath();
     fs.mkdirSync(path.dirname(mathhubEnvConfig), { recursive: true });
+    fs.mkdirSync(mathhubPath, { recursive: true });
     fs.writeFileSync(mathhubEnvConfig, mathhubPath);
 }
 
-async function getMMTVersion(jarpath: string): Promise<string | undefined> {
+async function getMMTVersion(jarPath: string, javaHome?: string): Promise<string | undefined> {
     return new Promise((resolve, reject) => {
         let stdout = "";
         let stderr = "";
-
-        const proc = exec(`java -classpath "${jarpath}" info.kwarc.mmt.api.frontend.Run "--version"`);
-        proc.stdout?.on("data", (data) => { stdout += data });
-        proc.stderr?.on("data", (data) => { stderr += data });
-
         const resolveWithResult = () => stdout.trim().length > 0
-            ? resolve(stdout)
+            ? resolve(stdout.trim())
             : reject(stderr);
-        proc.addListener("error", reject);
-        proc.addListener("exit", resolveWithResult);
-        proc.addListener("close", resolveWithResult);
+
+        // the following way allows jarPath and javaHome to contain spaces
+        const env = process.env;
+        if (javaHome) {
+            // adding specified java installation to PATH variable
+            env.PATH = `${path.join(javaHome, "bin")}:${env.PATH}`;
+        }
+        const args = ["-cp", jarPath, "info.kwarc.mmt.api.frontend.Run", "--version"];
+        const proc = spawn("java", args, { env })
+            .on("error", reject)
+            .on("exit", resolveWithResult)
+            .on("close", resolveWithResult);
+        proc.stdout.on("data", (data) => { stdout += data; });
+        proc.stderr.on("data", (data) => { stderr += data; });
     });
 }
 
 function singleValidationResponse(id: string, content: string, severity: SEVERITY): ValidatorResponse {
-    return { items: [{ severity, template: { id, content } }] }
+    return { items: [{ severity, template: { id, content } }] };
 }
 
 function wizardError(id: string, content: string): ValidatorResponse {
-    return singleValidationResponse(id, content, SEVERITY.ERROR)
+    return singleValidationResponse(id, content, SEVERITY.ERROR);
 }
 
 function wizardWarning(id: string, content: string): ValidatorResponse {
-    return singleValidationResponse(id, content, SEVERITY.WARN)
+    return singleValidationResponse(id, content, SEVERITY.WARN);
 }
 
 function wizardInfo(id: string, content: string): ValidatorResponse {
-    return singleValidationResponse(id, content, SEVERITY.INFO)
+    return singleValidationResponse(id, content, SEVERITY.INFO);
 }
 
-async function validateJarPath(parameters: any): Promise<ValidatorResponse> {
-    const jarPath = parameters.jarpath?.trim();
+async function validateJarPath(parameters: WorkflowData): Promise<ValidatorResponse> {
+    const jarPath = parameters.jarPath?.trim();
     if (!jarPath) {
-        return wizardWarning("jarpathValidation", "May not be empty");
-    } else if (!jarPath.toUpperCase().endsWith("/MMT.JAR")) {
-        return wizardError("jarpathValidation", "Filename must be 'mmt.jar'");
+        return wizardWarning("jarPath", "May not be empty");
     } else if (!fs.existsSync(jarPath)) {
-        return wizardError("jarpathValidation", "File does not exist.");
+        return wizardError("jarPath", "File does not exist");
     }
-    return getMMTVersion(jarPath).then((version) => {
-        return wizardInfo("jarpathValidation", `MMT Version: ${version}`);
+    return getMMTVersion(jarPath, parameters.javaHome).then((version) => {
+        return wizardInfo("jarPath", `MMT Version: ${version}`);
     }).catch((error) => {
-        return wizardWarning("jarpathValidation", "Could not get version, is Java installed?")
+        if (error.code === "ENOENT") {
+            return wizardError("jarPath", "Could not execute <code>java</code>");
+        }
+        return wizardError("jarPath", "An unknown error occurred! Could not get version");
     });
 }
 
-function canReadAndWrite(path: string): boolean {
+type FileAccess = "F_OK" | "R_OK" | "W_OK" | "X_OK";
+
+function hasFileAccess(path: string, access: FileAccess[]): boolean {
     try {
-        fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK);
+        fs.accessSync(path, access.reduce((p, c) => p | fs.constants[c], 0));
         return true;
     } catch {
         return false;
     }
 }
 
-async function validateMathhubPath(parameters: any): Promise<ValidatorResponse> {
-    const mathhubPath = parameters.mathhub?.trim();
+async function validateMathhubPath(parameters: WorkflowData): Promise<ValidatorResponse> {
+    const mathhubPath = parameters.mathhubPath?.trim();
     if (!mathhubPath) {
-        return wizardWarning("mathhubValidation", "May not be empty");
+        return wizardWarning("mathhubPath", "May not be empty");
     } else if (!fs.existsSync(mathhubPath)) {
-        return wizardError("mathhubValidation", "Path does not exist.");
+        return wizardWarning("mathhubPath", "Path does not exist but will be created");
     } else if (!fs.statSync(mathhubPath).isDirectory()) {
-        return wizardError("mathhubValidation", "Path is not a directory.");
-    } else if (!canReadAndWrite(mathhubPath)) {
-        return wizardError("mathhubValidation", "Missing read or write permissions.");
+        return wizardError("mathhubPath", "Path is not a directory");
+    } else if (!hasFileAccess(mathhubPath, ["R_OK", "W_OK"])) {
+        return wizardError("mathhubPath", "Missing read or write permissions");
     }
     return { items: [] };
 }
 
-export function setup(stexc: STeXContext) {
-    const jarpath = getJarpath();
-    const mathhub = getMathHub();
-    if (jarpath && mathhub) {
-        return;
+async function validateJavaHome(parameters: WorkflowData): Promise<ValidatorResponse> {
+    const javaHome = parameters.javaHome?.trim();
+    if (javaHome && !hasFileAccess(path.join(javaHome, "bin", "java"), ["X_OK"])) {
+        return wizardError("javaHome", "Could not find <code>java</code> executable");
     }
-    const def = <WizardDefinition>{
-        title: 'sTeX Setup',
-        description: "",
-        buttons: [{ id: BUTTONS.FINISH, label: "Finish" }],
-        pages: [{
-            title: "",
-            id: "stexsetup",
-            description: "",
-            asyncValidator: (parameters: any, previousParameters: any): Promise<ValidatorResponse>[] => [
-                validateJarPath(parameters),
-                validateMathhubPath(parameters)
-            ],
-            fields: [
-                {
-                    id: "jarsection",
-                    label: "MMT",
-                    description: "This Plugin needs to know the location of your MMT.jar, which you can download" +
-                        " <a href='https://github.com/UniFormal/MMT/releases'>here</a>",
-                    childFields: [{
-                        id: "jarpath",
-                        label: "MMT.jar",
-                        initialValue: jarpath,
-                        placeholder: "/path/to/mmt.jar",
-                        type: "file-picker",
-                        description: ""
-                    }]
-                },
-                {
-                    id: "mathhubsection",
-                    label: "MathHub Path",
-                    description: "It also needs to know the location of you MathHub-Directory",
-                    childFields: [{
-                        id: "mathhub",
-                        label: "MathHub",
-                        type: "file-picker",
-                        dialogOptions: {
-                            canSelectFiles: false,
-                            canSelectFolders: true
-                        },
-                        placeholder: "/path/to/mathhub-directory",
-                        initialValue: mathhub,
-                        initialState: { enabled: !mathhub },
-                        description: "<br>The directory where all MathHub/MMT archives are stored.<br><i>Can be a new (empty) directory.</i>"
-                    }]
-                }
-            ]
-        }],
-        workflowManager: <IWizardWorkflowManager>{
-            canFinish(wizard: WebviewWizard, data: any): boolean {
-                return data.jarpath && data.mathhub;
-            },
-            performFinish(wizard: WebviewWizard, data: any): Promise<PerformFinishResponse | null> {
-                if (!mathhub && data.mathhub) {
-                    setMathHub(data.mathhub);
-                }
-                const returnObject = vscode.workspace.getConfiguration("stexide")
-                    .update("jarpath", data.jarpath, vscode.ConfigurationTarget.Global)
-                    .then(() => {
-                        launchSTeXServerWithArgs(stexc, data.jarpath, data.mathhub);
-                        vscode.commands.executeCommand("setContext", "stex:enabled", true);
-                    })
-                return Promise.resolve({
-                    close: true,
-                    success: true,
-                    returnObject,
-                    templates: []
-                });
-            }
-        }
-    };
-    const wizard = new WebviewWizard("stexsetup", "stexsetup", stexc.vsc, def, new Map());
-    wizard.open();
+    return { items: [] };
 }
 
+export async function setup(stexc: STeXContext): Promise<void> {
+    const jarPath = getJarPath();
+    const mathhub = getMathHub();
+    if (jarPath && mathhub) {
+        return;
+    }
+    return new Promise<void>((resolve) => {
+        const def = <WizardDefinition>{
+            title: "sTeX Setup",
+            description: "",
+            buttons: [{ id: BUTTONS.FINISH, label: "Finish" }],
+            pages: [{
+                title: "",
+                asyncValidator: (parameters: WorkflowData, previousParameters: WorkflowData) => [
+                    validateJarPath(parameters),
+                    validateMathhubPath(parameters),
+                    validateJavaHome(parameters)
+                ],
+                fields: [
+                    {
+                        id: "mmt-section",
+                        label: "MMT",
+                        description: "This Plugin needs to know the location of your MMT.jar, which you can " +
+                            "download <a href='https://github.com/UniFormal/MMT/releases'>here</a>.",
+                        childFields: [{
+                            id: "jarPath",
+                            label: "Select <code>MMT.jar</code>",
+                            initialValue: jarPath,
+                            placeholder: "/path/to/mmt.jar",
+                            type: "file-picker",
+                        }]
+                    },
+                    {
+                        id: "mathhub-section",
+                        label: "MathHub",
+                        description: "It also needs to know the location of you MathHub directory" +
+                            "(MathHub/MMT archives are stored there).<br><i>Can be a new (empty) directory.</i>",
+                        childFields: [{
+                            id: "mathhubPath",
+                            label: "Select directory",
+                            type: "file-picker",
+                            dialogOptions: {
+                                canSelectFiles: false,
+                                canSelectFolders: true
+                            },
+                            placeholder: "/path/to/mathhub-directory",
+                            initialValue: mathhub,
+                            initialState: { enabled: !mathhub },
+                        }]
+                    },
+                    {
+                        id: "java-section",
+                        label: "Java",
+                        description: "Java is required. Could not find <code>JAVA_HOME</code> in environment " +
+                            "variables.<br>Please select the Java installation directory.",
+                        childFields: [{
+                            id: "javaHome",
+                            label: "Select directory",
+                            type: "file-picker",
+                            dialogOptions: {
+                                canSelectFiles: false,
+                                canSelectFolders: true
+                            },
+                            initialState: {
+                                visible: !process.env.JAVA_HOME
+                            }
+                        }]
+                    }
+                ]
+            }],
+            workflowManager: <GenericWizardWorkflowManager<WorkflowData>>{
+                canFinish(wizard: WebviewWizard, data: WorkflowData): boolean {
+                    return !!data.jarPath && !!data.mathhubPath;
+                },
+                performFinish(wizard: WebviewWizard, data: WorkflowData): Promise<PerformFinishResponse | null> {
+                    if (!mathhub && data.mathhubPath) {
+                        setMathHub(data.mathhubPath);
+                    }
+                    const configStore = vscode.workspace.getConfiguration("stexide");
+                    const returnObject = Promise.all([
+                        configStore.update("mmt.jarPath", data.jarPath, vscode.ConfigurationTarget.Global),
+                        configStore.update("mmt.javaHome", data.javaHome ?? "", vscode.ConfigurationTarget.Global),
+                    ])
+                        .then(() => vscode.commands.executeCommand("setContext", "stex:enabled", true))
+                        .then(() => resolve());
+                    return Promise.resolve({
+                        close: true,
+                        success: true,
+                        returnObject,
+                        templates: []
+                    });
+                }
+            }
+        };
+        const wizard = new WebviewWizard("stexsetup", "stexsetup", stexc.vsc, def, new Map());
+        wizard.open();
+    });
+}
+
+type WorkflowData = {
+    mathhubPath?: string,
+    jarPath?: string,
+    javaHome?: string
+};
+
+interface GenericWizardWorkflowManager<T> extends IWizardWorkflowManager {
+    canFinish?(wizard: WebviewWizard, data: T): boolean;
+    performFinish(wizard: WebviewWizard, data: T): Promise<PerformFinishResponse | null>;
+    getNextPage?(page: IWizardPage, data: T): IWizardPage | null;
+    getPreviousPage?(page: IWizardPage, data: T): IWizardPage | null;
+    performCancel?(): void;
+}

--- a/src/nonweb/setup.ts
+++ b/src/nonweb/setup.ts
@@ -1,151 +1,189 @@
+import { IWizardWorkflowManager, PerformFinishResponse, SEVERITY, BUTTONS, ValidatorResponse, WebviewWizard, WizardDefinition } from "@redhat-developer/vscode-wizard";
+import { launchSTeXServerWithArgs } from "./launches";
 import { STeXContext } from "../shared/context";
-import * as vscode from 'vscode';
-import {PerformFinishResponse, WebviewWizard, WizardDefinition} from "vscode-wizard";
+import { exec } from "child_process";
+import * as vscode from "vscode";
+import * as path from "path";
 import * as fs from "fs";
-import { getJavaHome, javaErr } from "../util/java";
-import path = require("path");
-import { exec, spawn } from "child_process";
-import { launchLocal, launchSTeXServerWithArgs } from "./launches";
-import { currentPanels } from "vscode-wizard/lib/pageImpl";
+
+
+export function getMathhubEnvConfigPath(): string {
+    return path.join((process.env.HOME || process.env.USERPROFILE) as string, ".stex", "mathhub.path");
+}
 
 export function getMathHub(): string | undefined {
-    let mathhub = process.env.MATHHUB;
+    const mathhub = process.env.MATHHUB;
     if (mathhub) {
         return mathhub;
-    } else {
-        let filepath = (process.env.HOME?process.env.HOME:process.env.USERPROFILE) + "/.stex";
-        let file = filepath + "/mathhub.path";
-        if (fs.existsSync(file)) {
-            return fs.readFileSync(file).toString().trim();
-        } else {
-            return undefined;
-        }
+    }
+    const mathhubEnvConfig = getMathhubEnvConfigPath()
+    if (fs.existsSync(mathhubEnvConfig)) {
+        return fs.readFileSync(mathhubEnvConfig).toString().trim();
+    }
+    return undefined;
+}
+
+export function getJarpath(): string | undefined {
+    const config = vscode.workspace.getConfiguration("stexide");
+    return config.get<string>("jarpath")?.trim();
+}
+
+function setMathHub(mathhubPath: string) {
+    const mathhubEnvConfig = getMathhubEnvConfigPath()
+    fs.mkdirSync(path.dirname(mathhubEnvConfig), { recursive: true });
+    fs.writeFileSync(mathhubEnvConfig, mathhubPath);
+}
+
+async function getMMTVersion(jarpath: string): Promise<string | undefined> {
+    return new Promise((resolve, reject) => {
+        let stdout = "";
+        let stderr = "";
+
+        const proc = exec(`java -classpath "${jarpath}" info.kwarc.mmt.api.frontend.Run "--version"`);
+        proc.stdout?.on("data", (data) => { stdout += data });
+        proc.stderr?.on("data", (data) => { stderr += data });
+
+        const resolveWithResult = () => stdout.trim().length > 0
+            ? resolve(stdout)
+            : reject(stderr);
+        proc.addListener("error", reject);
+        proc.addListener("exit", resolveWithResult);
+        proc.addListener("close", resolveWithResult);
+    });
+}
+
+function singleValidationResponse(id: string, content: string, severity: SEVERITY): ValidatorResponse {
+    return { items: [{ severity, template: { id, content } }] }
+}
+
+function wizardError(id: string, content: string): ValidatorResponse {
+    return singleValidationResponse(id, content, SEVERITY.ERROR)
+}
+
+function wizardWarning(id: string, content: string): ValidatorResponse {
+    return singleValidationResponse(id, content, SEVERITY.WARN)
+}
+
+function wizardInfo(id: string, content: string): ValidatorResponse {
+    return singleValidationResponse(id, content, SEVERITY.INFO)
+}
+
+async function validateJarPath(parameters: any): Promise<ValidatorResponse> {
+    const jarPath = parameters.jarpath?.trim();
+    if (!jarPath) {
+        return wizardWarning("jarpathValidation", "May not be empty");
+    } else if (!jarPath.toUpperCase().endsWith("/MMT.JAR")) {
+        return wizardError("jarpathValidation", "Filename must be 'mmt.jar'");
+    } else if (!fs.existsSync(jarPath)) {
+        return wizardError("jarpathValidation", "File does not exist.");
+    }
+    return getMMTVersion(jarPath).then((version) => {
+        return wizardInfo("jarpathValidation", `MMT Version: ${version}`);
+    }).catch((error) => {
+        return wizardWarning("jarpathValidation", "Could not get version, is Java installed?")
+    });
+}
+
+function canReadAndWrite(path: string): boolean {
+    try {
+        fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK);
+        return true;
+    } catch {
+        return false;
     }
 }
 
-export function getJarpath() : string | undefined {
-	let config = vscode.workspace.getConfiguration("stexide");
-	return config.get("jarpath");
-}
-
-function setMathHub(path : string) {
-    let filepath = (process.env.HOME?process.env.HOME:process.env.USERPROFILE) + "/.stex";
-    let file = filepath + "/mathhub.path";
-    if (!fs.existsSync(filepath)) {
-        fs.mkdirSync(filepath);
-    } 
-    fs.writeFileSync(file,path);
-}
-
-async function getMMTVersion(stexc: STeXContext,jarpath: string): Promise<string | undefined> {
-	/*return await getJavaHome().catch(err => {
-        javaErr(stexc);
-        return undefined;
-    })
-	.then(async javaHome => {
-        if (!javaHome) {
-            javaErr(stexc);
-            return undefined;
-        }
-	    let javaPath = path.join(javaHome, "bin", "java");*/
-        let out = "";
-        let p = new Promise((resolve,reject) => {
-            let e = exec("java -classpath \"" + jarpath + "\" info.kwarc.mmt.api.frontend.Run \"--version\"").stdout?.on('data',data => {
-                out += data;
-            });
-            e?.addListener("error", reject);
-            e?.addListener("exit",resolve);
-            e?.addListener("close",resolve);
-        });
-        await p;
-        if (out === "") {
-            return undefined;
-        } else {
-            return out;
-        }
-   // });
+async function validateMathhubPath(parameters: any): Promise<ValidatorResponse> {
+    const mathhubPath = parameters.mathhub?.trim();
+    if (!mathhubPath) {
+        return wizardWarning("mathhubValidation", "May not be empty");
+    } else if (!fs.existsSync(mathhubPath)) {
+        return wizardError("mathhubValidation", "Path does not exist.");
+    } else if (!fs.statSync(mathhubPath).isDirectory()) {
+        return wizardError("mathhubValidation", "Path is not a directory.");
+    } else if (!canReadAndWrite(mathhubPath)) {
+        return wizardError("mathhubValidation", "Missing read or write permissions.");
+    }
+    return { items: [] };
 }
 
 export function setup(stexc: STeXContext) {
-    let jarpath = getJarpath();
-    let mathhub = getMathHub();
-	if ((!jarpath || jarpath === "") || !mathhub) {
-        let validjar = false;
-        let currentjar = "";
-		let def = {
-			title: 'sTeX Setup',
-			description: "",
-			pages: [{
-				title: "",
-				id: "stexsetup",
-				description:"",
-				fields:[
-				{
-					id:"jarsection",
-					label:"MMT",
-					description:"This Plugin needs to know the location of your MMT.jar, which you can download" +
-					" <a href='https://github.com/UniFormal/MMT/releases'>here</a>",
-					childFields:[{
-						id:"jarpath",
-						label:"MMT.jar",
-						initialValue:jarpath,
-						type:"file-picker",
-                        description:""
-					}]
-				},
-				{
-					id:"mathhubsection",
-					label:"MathHub Path",
-					description:"It also needs to know the location of you MathHub-Directory:",
-					childFields:[{
-						id:"mathhub",
-						label:"MathHub",
-						type:"textbox",
-						initialValue:mathhub? mathhub : "/some/directory/path",
-						initialState:{enabled:mathhub?false:true},
-						description:mathhub?"MathHub path provided by environment variable or .mathhub-file":""
-					}]
-				}
-			]
-			}],
-			workflowManager: {
-				canFinish(wizard: WebviewWizard, data:any): boolean {
-                    let jar : string | undefined = data.jarpath;
-                    if (!jar || !jar.trim().toUpperCase().endsWith("MMT.JAR") || !fs.existsSync(jar.trim())) {return false;}
-                    if (jar !== currentjar) {
-                        currentjar = jar;
-                        getMMTVersion(stexc,jar.trim()).then(version => {
-                            if (version) {
-                                validjar = true;
-                                def.pages[0].fields[0].childFields[0].description = "MMT Version: " + version;
-                                wizard.pages = [];
-                                wizard.initialData.set("mathhub",data.mathhub).set("jarpath",data.jarpath);
-                                wizard.open();
-                            }
-                        });
-                        validjar = false;
-                    }
-                    return validjar && (mathhub !== undefined || data.mathhub !== undefined);
-				},
-				performFinish(wizard: WebviewWizard, data:any): Promise<PerformFinishResponse | null> {
-                    if (!mathhub && data.mathhub) {
-                        setMathHub(data.mathhub);
-                    }
-
-					return Promise.resolve({
-                        close:true,
-                        success:true,
-                        returnObject:
-                        vscode.workspace.getConfiguration("stexide").update("jarpath",data.jarpath,vscode.ConfigurationTarget.Global).then(() => {
-                            launchSTeXServerWithArgs(stexc,data.jarpath,data.mathhub);
-                            vscode.commands.executeCommand("setContext", "stex:enabled", true);
-                        }),
-                        templates:[]
-                    });
-				}
-			}
-		};
-		let wiz:WebviewWizard = new WebviewWizard("stexsetup","stexsetup",stexc.vsc,def,new Map());
-		wiz.open();
-	}
+    const jarpath = getJarpath();
+    const mathhub = getMathHub();
+    if (jarpath && mathhub) {
+        return;
+    }
+    const def = <WizardDefinition>{
+        title: 'sTeX Setup',
+        description: "",
+        buttons: [{ id: BUTTONS.FINISH, label: "Finish" }],
+        pages: [{
+            title: "",
+            id: "stexsetup",
+            description: "",
+            asyncValidator: (parameters: any, previousParameters: any): Promise<ValidatorResponse>[] => [
+                validateJarPath(parameters),
+                validateMathhubPath(parameters)
+            ],
+            fields: [
+                {
+                    id: "jarsection",
+                    label: "MMT",
+                    description: "This Plugin needs to know the location of your MMT.jar, which you can download" +
+                        " <a href='https://github.com/UniFormal/MMT/releases'>here</a>",
+                    childFields: [{
+                        id: "jarpath",
+                        label: "MMT.jar",
+                        initialValue: jarpath,
+                        placeholder: "/path/to/mmt.jar",
+                        type: "file-picker",
+                        description: ""
+                    }]
+                },
+                {
+                    id: "mathhubsection",
+                    label: "MathHub Path",
+                    description: "It also needs to know the location of you MathHub-Directory",
+                    childFields: [{
+                        id: "mathhub",
+                        label: "MathHub",
+                        type: "file-picker",
+                        dialogOptions: {
+                            canSelectFiles: false,
+                            canSelectFolders: true
+                        },
+                        placeholder: "/path/to/mathhub-directory",
+                        initialValue: mathhub,
+                        initialState: { enabled: !mathhub },
+                        description: "<br>The directory where all MathHub/MMT archives are stored.<br><i>Can be a new (empty) directory.</i>"
+                    }]
+                }
+            ]
+        }],
+        workflowManager: <IWizardWorkflowManager>{
+            canFinish(wizard: WebviewWizard, data: any): boolean {
+                return data.jarpath && data.mathhub;
+            },
+            performFinish(wizard: WebviewWizard, data: any): Promise<PerformFinishResponse | null> {
+                if (!mathhub && data.mathhub) {
+                    setMathHub(data.mathhub);
+                }
+                const returnObject = vscode.workspace.getConfiguration("stexide")
+                    .update("jarpath", data.jarpath, vscode.ConfigurationTarget.Global)
+                    .then(() => {
+                        launchSTeXServerWithArgs(stexc, data.jarpath, data.mathhub);
+                        vscode.commands.executeCommand("setContext", "stex:enabled", true);
+                    })
+                return Promise.resolve({
+                    close: true,
+                    success: true,
+                    returnObject,
+                    templates: []
+                });
+            }
+        }
+    };
+    const wizard = new WebviewWizard("stexsetup", "stexsetup", stexc.vsc, def, new Map());
+    wizard.open();
 }
+


### PR DESCRIPTION
since I had some issues using it as it was before I thought I'd invest some hours...

* update wizard version (package name changed)
* validate inputs, give error messages and hints [2]
* use file picker also for mathhub dir
* bugfix: validate jar paths entered manually without file picker 

TODO (discuss)
* should the MathHub path really be fix after set once?
* is it really necessary to check if the jar is called `MMT.jar`? how about eg. versioned file names?
* can / should we check a signature of `MMT.jar` before running it?
* currently I give a warning [3] if the mmt version could not be detected
  - should this rather be an error?
  - in my case it is because `java` is not in `$PATH`, wasn't there some while ago an option to select the java path?
* please have a look at the hint-texts

Initial view looks now like this

![image](https://user-images.githubusercontent.com/74305777/191069303-d2846ed2-855a-4fff-ad78-eda06edf177e.png)


[2] Validation errors look like this

![image](https://user-images.githubusercontent.com/74305777/191069581-13f83692-1ba7-4de6-89e9-d7a27da5fc6b.png)

------
[3]
![image](https://user-images.githubusercontent.com/74305777/191070902-94f61d41-5cc7-45b0-8710-9caa2cb330b7.png)
